### PR TITLE
Setting relativeRotation of a shape correctly

### DIFF
--- a/src/dynamics/WorldAdd.js
+++ b/src/dynamics/WorldAdd.js
@@ -154,7 +154,10 @@ OIMO.World.prototype.add = function(obj){
             if(i>0){
                 //shapes[i].position.init(p[0]+p[n+0], p[1]+p[n+1], p[2]+p[n+2] );
                 shapes[i].relativePosition = new OIMO.Vec3( p[n], p[n+1], p[n+2] );
-                if(r[n2+0]) shapes[i].relativeRotation = [ r[n2], r[n2+1], r[n2+2], r[n2+3] ];
+                if(r[n2+0]) {
+                    var q = body.rotationAxisToQuad(r[0], r[1], r[2], r[3]);
+                    shapes[i].relativeRotation = new OIMO.Mat33().setQuat(q);
+                }
             }
         } 
         


### PR DESCRIPTION
When creating a multi-shaped object, the relativeRotation is currently being set as an array. When calculating the mass (in setupMass), the relativeRotation is expected to be a Mat33.
This creates a quaternion from the rotation and sets the Mat33 object from this quaternion. 
It would be cleaner if I added a few help functions (like QuadToMatrix), but since this is not often used, those 2 objects created will not influence performance.
